### PR TITLE
A2 - Update the link of the GitHub Actions build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![Java CI](https://github.com/AY2526S2-CS2103-F11-3/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2526S2-CS2103-F11-3/tp/actions/workflows/gradle.yml)
 [![codecov](https://codecov.io/gh/AY2526S2-CS2103-F11-3/tp/graph/badge.svg?token=PSQYLXA22X)](https://codecov.io/gh/AY2526S2-CS2103-F11-3/tp)
 
 ![Ui](docs/images/Ui.png)


### PR DESCRIPTION
Fixes #28 