### PR TITLE
Fix: Storage Class Diagram in DG is outdated with irrelevant JsonAdaptedTag dependency

### DIFF
--- a/docs/diagrams/StorageClassDiagram.puml
+++ b/docs/diagrams/StorageClassDiagram.puml
@@ -3,10 +3,21 @@
 skinparam arrowThickness 1.1
 skinparam arrowColor STORAGE_COLOR
 skinparam classBackgroundColor STORAGE_COLOR
+skinparam ranksep 35
+skinparam nodesep 35
+top to bottom direction
+
+skinparam class<<spacer>> {
+BorderColor transparent
+BackgroundColor transparent
+FontColor transparent
+StereotypeFontColor transparent
+}
 
 package Storage as StoragePackage {
 
 package "UserPrefs Storage" #F4F6F6{
+Class UserPrefsSpacer <<spacer>>
 Class "<<interface>>\nUserPrefsStorage" as UserPrefsStorage
 Class JsonUserPrefsStorage
 }
@@ -19,7 +30,8 @@ Class "<<interface>>\nAddressBookStorage" as AddressBookStorage
 Class JsonAddressBookStorage
 Class JsonSerializableAddressBook
 Class JsonAdaptedPerson
-Class JsonAdaptedTag
+Class AddressBookLoadResult
+Class InvalidPersonRecord
 }
 
 }
@@ -28,16 +40,21 @@ Class HiddenOutside #FFFFFF
 HiddenOutside ..> Storage
 
 StorageManager .up.|> Storage
-StorageManager -up-> "1" UserPrefsStorage
-StorageManager -up-> "1" AddressBookStorage
+StorageManager --> "1" UserPrefsStorage
+StorageManager --> "1" AddressBookStorage
 
-Storage -left-|> UserPrefsStorage
-Storage -right-|> AddressBookStorage
+Storage --|> UserPrefsStorage
+Storage -left-|> AddressBookStorage
 
 JsonUserPrefsStorage .up.|> UserPrefsStorage
 JsonAddressBookStorage .up.|> AddressBookStorage
 JsonAddressBookStorage ..> JsonSerializableAddressBook
+JsonAddressBookStorage ..> AddressBookLoadResult
 JsonSerializableAddressBook --> "*" JsonAdaptedPerson
-JsonAdaptedPerson --> "*" JsonAdaptedTag
+JsonSerializableAddressBook --> "*" InvalidPersonRecord
+InvalidPersonRecord --> "1" JsonAdaptedPerson
+
+StorageManager -[hidden]down-> UserPrefsSpacer
+UserPrefsSpacer -[hidden]down-> UserPrefsStorage
 
 @enduml


### PR DESCRIPTION
Fixes #264

<img width="714" height="476" alt="Screenshot 2026-04-12 at 9 07 10 PM" src="https://github.com/user-attachments/assets/f2ffd880-670a-46ac-b408-4bc23cee3630" />


StorageManager implements Storage and depends on exactly one UserPrefsStorage and one AddressBookStorage. 

Storage itself extends both UserPrefsStorage and AddressBookStorage
- JsonUserPrefsStorage implements UserPrefsStorage

JsonAddressBookStorage implements AddressBookStorage
- JsonAddressBookStorage should depend on JsonSerializableAddressBook for JSON conversion and on AddressBookLoadResult because loading now returns metadata, not just the address book. JsonSerializableAddressBook should depend on many JsonAdaptedPerson objects, and it should also reference many InvalidPersonRecord objects because invalid or duplicate entries are collected during load. 
- Each InvalidPersonRecord wraps exactly one JsonAdaptedPerson plus one reason string.